### PR TITLE
Add multi guards support + refactoring

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -58,6 +58,7 @@ abstract class Broadcaster implements BroadcasterContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $channel
+     * @param  array   $options
      * @return mixed
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
@@ -271,7 +272,7 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * Retrieve options for a certain channel
      *
-     * @param  string $channel
+     * @param  string  $channel
      * @return array
      */
     protected function retrieveChannelOptions($channel)

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -136,7 +136,6 @@ class PusherBroadcaster extends Broadcaster
      * Return true if channel is protected by authentication
      *
      * @param  string  $channel
-     *
      * @return bool
      */
     public function isGuardedChannel($channel)
@@ -148,7 +147,6 @@ class PusherBroadcaster extends Broadcaster
      * Remove prefix from channel name
      *
      * @param  string  $channel
-     *
      * @return string
      */
     public function normalizeChannelName($channel)

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -109,7 +109,6 @@ class RedisBroadcaster extends Broadcaster
      * Return true if channel is protected by authentication
      *
      * @param  string  $channel
-     *
      * @return bool
      */
     public function isGuardedChannel($channel)
@@ -121,7 +120,6 @@ class RedisBroadcaster extends Broadcaster
      * Remove prefix from channel name
      *
      * @param  string  $channel
-     *
      * @return string
      */
     public function normalizeChannelName($channel)

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -45,21 +45,12 @@ class RedisBroadcaster extends Broadcaster
      */
     public function auth($request)
     {
-        $channelName = Str::startsWith($request->channel_name, 'private-')
-            ? Str::replaceFirst('private-', '', $request->channel_name)
-            : Str::replaceFirst('presence-', '', $request->channel_name);
+        $channelName = $this->normalizeChannelName($request->channel_name);
 
-        $options = [];
-        foreach ($this->channelsOptions as $pattern => $opts) {
-            if (! Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channelName)) {
-                continue;
-            }
+        $options = $this->retrieveChannelOptions($channelName);
 
-            $options = $opts;
-        }
-
-        if (Str::startsWith($request->channel_name, ['private-', 'presence-']) &&
-            ! $this->retrieveUser($request, $request->channel_name)) {
+        if ($this->isGuardedChannel($request->channel_name) &&
+            ! $this->retrieveUser($request, $options['guards'] ?? null)) {
             throw new AccessDeniedHttpException;
         }
 
@@ -81,8 +72,12 @@ class RedisBroadcaster extends Broadcaster
             return json_encode($result);
         }
 
+        $options = $this->retrieveChannelOptions(
+            $this->normalizeChannelName($request->channel_name)
+        );
+
         return json_encode(['channel_data' => [
-            'user_id' => $this->retrieveUser($request, $request->channel_name)->getAuthIdentifier(),
+            'user_id' => $this->retrieveUser($request, $options['guards'] ?? null)->getAuthIdentifier(),
             'user_info' => $result,
         ]]);
     }
@@ -108,5 +103,34 @@ class RedisBroadcaster extends Broadcaster
         foreach ($this->formatChannels($channels) as $channel) {
             $connection->publish($channel, $payload);
         }
+    }
+
+    /**
+     * Return true if channel is protected by authentication
+     *
+     * @param  string  $channel
+     *
+     * @return bool
+     */
+    public function isGuardedChannel($channel)
+    {
+        return Str::startsWith($channel, ['private-', 'presence-']);
+    }
+
+    /**
+     * Remove prefix from channel name
+     *
+     * @param  string  $channel
+     *
+     * @return string
+     */
+    public function normalizeChannelName($channel)
+    {
+        if ($this->isGuardedChannel($channel)) {
+            return Str::startsWith($channel, 'private-')
+                ? Str::replaceFirst('private-', '', $channel)
+                : Str::replaceFirst('presence-', '', $channel);
+        }
+        return $channel;
     }
 }


### PR DESCRIPTION
`guards` option can be a string (if you use only one guard) or an array of guards

By default, if `guards` is not provided, the fallback is to use `$request->user()` like in current version of Laravel.