### PR TITLE
Refactoring + tests

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -41,7 +41,7 @@ abstract class Broadcaster implements BroadcasterContract
      *
      * @param  string  $channel
      * @param  callable|string  $callback
-     * @param  array   $options
+     * @param  array  $options
      * @return $this
      */
     public function channel($channel, $callback, $options = [])
@@ -288,9 +288,10 @@ abstract class Broadcaster implements BroadcasterContract
     }
 
     /**
-     * Retrieve user by checking in provided guards
+     * Retrieve request user using optional guards
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  string  $channel
      * @return mixed
      */
     protected function retrieveUser($request, $channel)

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -64,7 +64,7 @@ abstract class Broadcaster implements BroadcasterContract
     protected function verifyUserCanAccessChannel($request, $channel)
     {
         foreach ($this->channels as $pattern => $callback) {
-            if (! Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel)) {
+            if (! $this->channelNameMatchPattern($channel, $pattern)) {
                 continue;
             }
 
@@ -277,7 +277,7 @@ abstract class Broadcaster implements BroadcasterContract
     protected function retrieveChannelOptions($channel)
     {
         foreach ($this->channelsOptions as $pattern => $opts) {
-            if (! Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel)) {
+            if (! $this->channelNameMatchPattern($channel, $pattern)) {
                 continue;
             }
 
@@ -313,5 +313,17 @@ abstract class Broadcaster implements BroadcasterContract
         }
 
         return null;
+    }
+
+    /**
+     * Check if channel name from request match a pattern from registered channels
+     *
+     * @param  string  $channel
+     * @param  string  $pattern
+     * @return bool
+     */
+    protected function channelNameMatchPattern($channel, $pattern)
+    {
+        return Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel);
     }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -39,15 +39,13 @@ class PusherBroadcaster extends Broadcaster
     {
         $channelName = $this->normalizeChannelName($request->channel_name);
 
-        $options = $this->retrieveChannelOptions($channelName);
-
         if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $options['guards'] ?? null)) {
+            ! $this->retrieveUser($request, $channelName)) {
             throw new AccessDeniedHttpException;
         }
 
         return parent::verifyUserCanAccessChannel(
-            $request, $channelName, $options
+            $request, $channelName
         );
     }
 
@@ -66,15 +64,13 @@ class PusherBroadcaster extends Broadcaster
             );
         }
 
-        $options = $this->retrieveChannelOptions(
-            $this->normalizeChannelName($request->channel_name)
-        );
+        $channelName = $this->normalizeChannelName($request->channel_name);
 
         return $this->decodePusherResponse(
             $request,
             $this->pusher->presence_auth(
                 $request->channel_name, $request->socket_id,
-                $this->retrieveUser($request, $options['guards'] ?? null)->getAuthIdentifier(), $result
+                $this->retrieveUser($request, $channelName)->getAuthIdentifier(), $result
             )
         );
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class PusherBroadcaster extends Broadcaster
 {
+    use UsePusherChannelsNames;
+
     /**
      * The Pusher SDK instance.
      *
@@ -126,32 +128,5 @@ class PusherBroadcaster extends Broadcaster
     public function getPusher()
     {
         return $this->pusher;
-    }
-
-    /**
-     * Return true if channel is protected by authentication
-     *
-     * @param  string  $channel
-     * @return bool
-     */
-    public function isGuardedChannel($channel)
-    {
-        return Str::startsWith($channel, ['private-', 'presence-']);
-    }
-
-    /**
-     * Remove prefix from channel name
-     *
-     * @param  string  $channel
-     * @return string
-     */
-    public function normalizeChannelName($channel)
-    {
-        if ($this->isGuardedChannel($channel)) {
-            return Str::startsWith($channel, 'private-')
-                ? Str::replaceFirst('private-', '', $channel)
-                : Str::replaceFirst('presence-', '', $channel);
-        }
-        return $channel;
     }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class RedisBroadcaster extends Broadcaster
 {
+    use UsePusherChannelsNames;
+
     /**
      * The Redis instance.
      *
@@ -99,32 +100,5 @@ class RedisBroadcaster extends Broadcaster
         foreach ($this->formatChannels($channels) as $channel) {
             $connection->publish($channel, $payload);
         }
-    }
-
-    /**
-     * Return true if channel is protected by authentication
-     *
-     * @param  string  $channel
-     * @return bool
-     */
-    public function isGuardedChannel($channel)
-    {
-        return Str::startsWith($channel, ['private-', 'presence-']);
-    }
-
-    /**
-     * Remove prefix from channel name
-     *
-     * @param  string  $channel
-     * @return string
-     */
-    public function normalizeChannelName($channel)
-    {
-        if ($this->isGuardedChannel($channel)) {
-            return Str::startsWith($channel, 'private-')
-                ? Str::replaceFirst('private-', '', $channel)
-                : Str::replaceFirst('presence-', '', $channel);
-        }
-        return $channel;
     }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -47,15 +47,13 @@ class RedisBroadcaster extends Broadcaster
     {
         $channelName = $this->normalizeChannelName($request->channel_name);
 
-        $options = $this->retrieveChannelOptions($channelName);
-
         if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $options['guards'] ?? null)) {
+            ! $this->retrieveUser($request, $channelName)) {
             throw new AccessDeniedHttpException;
         }
 
         return parent::verifyUserCanAccessChannel(
-            $request, $channelName, $options
+            $request, $channelName
         );
     }
 
@@ -72,12 +70,10 @@ class RedisBroadcaster extends Broadcaster
             return json_encode($result);
         }
 
-        $options = $this->retrieveChannelOptions(
-            $this->normalizeChannelName($request->channel_name)
-        );
+        $channelName = $this->normalizeChannelName($request->channel_name);
 
         return json_encode(['channel_data' => [
-            'user_id' => $this->retrieveUser($request, $options['guards'] ?? null)->getAuthIdentifier(),
+            'user_id' => $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
             'user_info' => $result,
         ]]);
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelsNames.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelsNames.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Broadcasting\Broadcasters;
+
+use Illuminate\Support\Str;
+
+trait UsePusherChannelsNames
+{
+    /**
+     * Return true if channel is protected by authentication
+     *
+     * @param  string  $channel
+     * @return bool
+     */
+    public function isGuardedChannel($channel)
+    {
+        return Str::startsWith($channel, ['private-', 'presence-']);
+    }
+
+    /**
+     * Remove prefix from channel name
+     *
+     * @param  string  $channel
+     * @return string
+     */
+    public function normalizeChannelName($channel)
+    {
+        if ($this->isGuardedChannel($channel)) {
+            return Str::startsWith($channel, 'private-')
+                ? Str::replaceFirst('private-', '', $channel)
+                : Str::replaceFirst('presence-', '', $channel);
+        }
+        return $channel;
+    }
+}

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -219,6 +219,32 @@ class BroadcasterTest extends TestCase
 
         $broadcaster->retrieveUser($request, 'somechannel');
     }
+
+    /**
+     * @dataProvider channelNameMatchPatternProvider
+     */
+    public function testChannelNameMatchPattern($channel, $pattern, $shouldMatch)
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $this->assertEquals($shouldMatch, $broadcaster->channelNameMatchPattern($channel, $pattern));
+    }
+
+    public function channelNameMatchPatternProvider() {
+        return [
+            ['something', 'something', true],
+            ['something.23', 'something.{id}', true],
+            ['something.23.test', 'something.{id}.test', true],
+            ['something.23.test.42', 'something.{id}.test.{id2}', true],
+            ['something-23:test-42', 'something-{id}:test-{id2}', true],
+            ['something..test.42', 'something.{id}.test.{id2}', true],
+            ['23:string:test', '{id}:string:{text}', true],
+            ['something.23', 'something', false],
+            ['something.23.test.42', 'something.test.{id}', false],
+            ['something-23-test-42', 'something-{id}-test', false],
+            ['23:test', '{id}:test:abcd', false],
+        ];
+    }
 }
 
 class FakeBroadcaster extends Broadcaster
@@ -248,6 +274,11 @@ class FakeBroadcaster extends Broadcaster
     public function retrieveUser($request, $channel)
     {
         return parent::retrieveUser($request, $channel);
+    }
+
+    public function channelNameMatchPattern($channel, $pattern)
+    {
+        return parent::channelNameMatchPattern($channel, $pattern);
     }
 }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -108,10 +108,58 @@ class BroadcasterTest extends TestCase
 
         $options = [ 'a' => [ 'b', 'c' ] ];
         $broadcaster->channel('somechannel', function () {}, $options);
+    }
+
+    public function testCanRetrieveChannelsOptions()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $options = [ 'a' => [ 'b', 'c' ] ];
+        $broadcaster->channel('somechannel', function () {}, $options);
 
         $this->assertEquals(
             $options,
             $broadcaster->retrieveChannelOptions('somechannel')
+        );
+    }
+
+    public function testCanRetrieveChannelsOptionsUsingAChannelNameContainingArgs()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $options = [ 'a' => [ 'b', 'c' ] ];
+        $broadcaster->channel('somechannel.{id}.test.{text}', function () {}, $options);
+
+        $this->assertEquals(
+            $options,
+            $broadcaster->retrieveChannelOptions('somechannel.23.test.mytext')
+        );
+    }
+
+    public function testCanRetrieveChannelsOptionsWhenMultipleChannelsAreRegistered()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $options = [ 'a' => [ 'b', 'c' ] ];
+        $broadcaster->channel('somechannel', function () {});
+        $broadcaster->channel('someotherchannel', function () {}, $options);
+
+        $this->assertEquals(
+            $options,
+            $broadcaster->retrieveChannelOptions('someotherchannel')
+        );
+    }
+
+    public function testDontRetrieveChannelsOptionsWhenChannelDoesntExists()
+    {
+        $broadcaster = new FakeBroadcaster;
+
+        $options = [ 'a' => [ 'b', 'c' ] ];
+        $broadcaster->channel('somechannel', function () {}, $options);
+
+        $this->assertEquals(
+            [],
+            $broadcaster->retrieveChannelOptions('someotherchannel')
         );
     }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -11,6 +11,18 @@ use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 
 class BroadcasterTest extends TestCase
 {
+    /**
+     * @var \Illuminate\Tests\Broadcasting\FakeBroadcaster
+     */
+    public $broadcaster;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->broadcaster = new FakeBroadcaster;
+    }
+
     public function tearDown()
     {
         m::close();
@@ -18,26 +30,24 @@ class BroadcasterTest extends TestCase
 
     public function testExtractingParametersWhileCheckingForUserAccess()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $callback = function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {
         };
-        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', $callback);
+        $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', $callback);
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
 
         $callback = function ($user, BroadcasterTestEloquentModelStub $model, BroadcasterTestEloquentModelStub $model2, $something) {
         };
-        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{model2}.{nonModel}', 'asd.1.uid.something', $callback);
+        $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{model2}.{nonModel}', 'asd.1.uid.something', $callback);
         $this->assertEquals(['model.1.instance', 'model.uid.instance', 'something'], $parameters);
 
         $callback = function ($user) {
         };
-        $parameters = $broadcaster->extractAuthParameters('asd', 'asd', $callback);
+        $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
         $this->assertEquals([], $parameters);
 
         $callback = function ($user, $something) {
         };
-        $parameters = $broadcaster->extractAuthParameters('asd', 'asd', $callback);
+        $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
         $this->assertEquals([], $parameters);
 
         /*
@@ -52,16 +62,14 @@ class BroadcasterTest extends TestCase
         $container->instance(BindingRegistrar::class, $binder);
         $callback = function ($user, $model) {
         };
-        $parameters = $broadcaster->extractAuthParameters('something.{model}', 'something.1', $callback);
+        $parameters = $this->broadcaster->extractAuthParameters('something.{model}', 'something.1', $callback);
         $this->assertEquals(['bound'], $parameters);
         Container::setInstance(new Container);
     }
 
     public function testCanUseChannelClasses()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $parameters = $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', DummyBroadcastingChannel::class);
+        $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', DummyBroadcastingChannel::class);
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
     }
 
@@ -70,18 +78,14 @@ class BroadcasterTest extends TestCase
      */
     public function testUnknownChannelAuthHandlerTypeThrowsException()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
+        $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', 123);
     }
 
     public function testCanRegisterChannelsAsClasses()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('something', function () {
+        $this->broadcaster->channel('something', function () {
         });
-        $broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
+        $this->broadcaster->channel('somethingelse', DummyBroadcastingChannel::class);
     }
 
     /**
@@ -89,85 +93,70 @@ class BroadcasterTest extends TestCase
      */
     public function testNotFoundThrowsHttpException()
     {
-        $broadcaster = new FakeBroadcaster;
         $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
         };
-        $broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
+        $this->broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
     }
 
     public function testCanRegisterChannelsWithoutOptions()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {});
+        $this->broadcaster->channel('somechannel', function () {});
     }
 
     public function testCanRegisterChannelsWithOptions()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $options = [ 'a' => [ 'b', 'c' ] ];
-        $broadcaster->channel('somechannel', function () {}, $options);
+        $this->broadcaster->channel('somechannel', function () {}, $options);
     }
 
     public function testCanRetrieveChannelsOptions()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $options = [ 'a' => [ 'b', 'c' ] ];
-        $broadcaster->channel('somechannel', function () {}, $options);
+        $this->broadcaster->channel('somechannel', function () {}, $options);
 
         $this->assertEquals(
             $options,
-            $broadcaster->retrieveChannelOptions('somechannel')
+            $this->broadcaster->retrieveChannelOptions('somechannel')
         );
     }
 
     public function testCanRetrieveChannelsOptionsUsingAChannelNameContainingArgs()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $options = [ 'a' => [ 'b', 'c' ] ];
-        $broadcaster->channel('somechannel.{id}.test.{text}', function () {}, $options);
+        $this->broadcaster->channel('somechannel.{id}.test.{text}', function () {}, $options);
 
         $this->assertEquals(
             $options,
-            $broadcaster->retrieveChannelOptions('somechannel.23.test.mytext')
+            $this->broadcaster->retrieveChannelOptions('somechannel.23.test.mytext')
         );
     }
 
     public function testCanRetrieveChannelsOptionsWhenMultipleChannelsAreRegistered()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $options = [ 'a' => [ 'b', 'c' ] ];
-        $broadcaster->channel('somechannel', function () {});
-        $broadcaster->channel('someotherchannel', function () {}, $options);
+        $this->broadcaster->channel('somechannel', function () {});
+        $this->broadcaster->channel('someotherchannel', function () {}, $options);
 
         $this->assertEquals(
             $options,
-            $broadcaster->retrieveChannelOptions('someotherchannel')
+            $this->broadcaster->retrieveChannelOptions('someotherchannel')
         );
     }
 
     public function testDontRetrieveChannelsOptionsWhenChannelDoesntExists()
     {
-        $broadcaster = new FakeBroadcaster;
-
         $options = [ 'a' => [ 'b', 'c' ] ];
-        $broadcaster->channel('somechannel', function () {}, $options);
+        $this->broadcaster->channel('somechannel', function () {}, $options);
 
         $this->assertEquals(
             [],
-            $broadcaster->retrieveChannelOptions('someotherchannel')
+            $this->broadcaster->retrieveChannelOptions('someotherchannel')
         );
     }
 
     public function testRetrieveUserWithoutGuard()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {});
+        $this->broadcaster->channel('somechannel', function () {});
 
         $request = m::mock(\Illuminate\Http\Request::class);
         $request->shouldReceive('user')
@@ -177,15 +166,13 @@ class BroadcasterTest extends TestCase
 
         $this->assertInstanceOf(
             DummyUser::class,
-            $broadcaster->retrieveUser($request, 'somechannel')
+            $this->broadcaster->retrieveUser($request, 'somechannel')
         );
     }
 
     public function testRetrieveUserWithOneGuardUsingAStringForSpecifyingGuard()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {}, ['guards' => 'myguard']);
+        $this->broadcaster->channel('somechannel', function () {}, ['guards' => 'myguard']);
 
         $request = m::mock(\Illuminate\Http\Request::class);
         $request->shouldReceive('user')
@@ -195,16 +182,14 @@ class BroadcasterTest extends TestCase
 
         $this->assertInstanceOf(
             DummyUser::class,
-            $broadcaster->retrieveUser($request, 'somechannel')
+            $this->broadcaster->retrieveUser($request, 'somechannel')
         );
     }
 
     public function testRetrieveUserWithMultipleGuardsAndRespectGuardsOrder()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {}, ['guards' => ['myguard1', 'myguard2']]);
-        $broadcaster->channel('someotherchannel', function () {}, ['guards' => ['myguard2', 'myguard1']]);
+        $this->broadcaster->channel('somechannel', function () {}, ['guards' => ['myguard1', 'myguard2']]);
+        $this->broadcaster->channel('someotherchannel', function () {}, ['guards' => ['myguard2', 'myguard1']]);
 
 
         $request = m::mock(\Illuminate\Http\Request::class);
@@ -220,20 +205,18 @@ class BroadcasterTest extends TestCase
 
         $this->assertInstanceOf(
             DummyUser::class,
-            $broadcaster->retrieveUser($request, 'somechannel')
+            $this->broadcaster->retrieveUser($request, 'somechannel')
         );
 
         $this->assertInstanceOf(
             DummyUser::class,
-            $broadcaster->retrieveUser($request, 'someotherchannel')
+            $this->broadcaster->retrieveUser($request, 'someotherchannel')
         );
     }
 
     public function testRetrieveUserDontUseDefaultGuardWhenOneGuardSpecified()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {}, ['guards' => 'myguard']);
+        $this->broadcaster->channel('somechannel', function () {}, ['guards' => 'myguard']);
 
         $request = m::mock(\Illuminate\Http\Request::class);
         $request->shouldReceive('user')
@@ -243,15 +226,12 @@ class BroadcasterTest extends TestCase
         $request->shouldNotReceive('user')
                 ->withNoArgs();
 
-        $broadcaster->retrieveUser($request, 'somechannel');
+        $this->broadcaster->retrieveUser($request, 'somechannel');
     }
 
     public function testRetrieveUserDontUseDefaultGuardWhenMultipleGuardsSpecified()
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $broadcaster->channel('somechannel', function () {}, ['guards' => ['myguard1', 'myguard2']]);
-
+        $this->broadcaster->channel('somechannel', function () {}, ['guards' => ['myguard1', 'myguard2']]);
 
         $request = m::mock(\Illuminate\Http\Request::class);
         $request->shouldReceive('user')
@@ -265,7 +245,7 @@ class BroadcasterTest extends TestCase
         $request->shouldNotReceive('user')
                 ->withNoArgs();
 
-        $broadcaster->retrieveUser($request, 'somechannel');
+        $this->broadcaster->retrieveUser($request, 'somechannel');
     }
 
     /**
@@ -273,9 +253,7 @@ class BroadcasterTest extends TestCase
      */
     public function testChannelNameMatchPattern($channel, $pattern, $shouldMatch)
     {
-        $broadcaster = new FakeBroadcaster;
-
-        $this->assertEquals($shouldMatch, $broadcaster->channelNameMatchPattern($channel, $pattern));
+        $this->assertEquals($shouldMatch, $this->broadcaster->channelNameMatchPattern($channel, $pattern));
     }
 
     public function channelNameMatchPatternProvider() {

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting;
+
+use Illuminate\Broadcasting\Broadcasters\PusherBroadcaster;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class PusherBroadcasterTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Broadcasting\Broadcasters\PusherBroadcaster
+     */
+    public $broadcaster;
+
+    public $pusher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->pusher = m::mock('Pusher\Pusher');
+        $this->broadcaster = m::mock(PusherBroadcaster::class, [$this->pusher])->makePartial();
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testChannelNameNormalization($requestChannelName, $normalizedName)
+    {
+        $this->assertEquals(
+            $normalizedName,
+            $this->broadcaster->normalizeChannelName($requestChannelName)
+        );
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
+    {
+        $this->assertEquals(
+            $guarded,
+            $this->broadcaster->isGuardedChannel($requestChannelName)
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    {
+        $this->broadcaster->channel('test', function() {
+            return true;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    {
+        $this->broadcaster->channel('test', function() {
+            return false;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    {
+        $this->broadcaster->channel('test', function() {
+            return true;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('private-test')
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    {
+        $returnData = [1, 2, 3, 4];
+        $this->broadcaster->channel('test', function() use ($returnData) {
+            return $returnData;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    {
+        $this->broadcaster->channel('test', function() {
+            return;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    {
+        $this->broadcaster->channel('test', function() {
+            return [1, 2, 3, 4];
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('presence-test')
+        );
+    }
+
+    public function testValidAuthenticationResponseCallPusherSocketAuthMethodWithPrivateChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('private-test');
+
+        $data = [
+            'auth' => 'abcd:efgh'
+        ];
+
+        $this->pusher->shouldReceive('socket_auth')
+                     ->once()
+                     ->andReturn(json_encode($data));
+
+        $this->assertEquals(
+            $data,
+            $this->broadcaster->validAuthenticationResponse($request, true)
+        );
+    }
+
+    public function testValidAuthenticationResponseCallPusherPresenceAuthMethodWithPresenceChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('presence-test');
+
+        $data = [
+            'auth' => 'abcd:efgh',
+            'channel_data' => [
+                'user_id' => 42,
+                'user_info' => [1, 2, 3, 4],
+            ],
+        ];
+
+        $this->pusher->shouldReceive('presence_auth')
+                     ->once()
+                     ->andReturn(json_encode($data));
+
+        $this->assertEquals(
+            $data,
+            $this->broadcaster->validAuthenticationResponse($request, true)
+        );
+    }
+
+    public function channelsProvider()
+    {
+        $prefixesInfos = [
+            ['prefix' => 'private-', 'guarded' => true],
+            ['prefix' => 'presence-', 'guarded' => true],
+            ['prefix' => '', 'guarded' => false],
+        ];
+
+        $channels = [
+            'test',
+            'test-channel',
+            'test-private-channel',
+            'test-presence-channel',
+            'abcd.efgh',
+            'abcd.efgh.ijkl',
+            'test.{param}',
+            'test-{param}',
+            '{a}.{b}',
+            '{a}-{b}',
+            '{a}-{b}.{c}',
+        ];
+
+        $tests = [];
+        foreach ($prefixesInfos as $prefixInfos) {
+            foreach ($channels as $channel) {
+                $tests[] = [
+                    $prefixInfos['prefix'] . $channel,
+                    $channel,
+                    $prefixInfos['guarded'],
+                ];
+            }
+        }
+
+        $tests[] = ['private-private-test' , 'private-test', true];
+        $tests[] = ['private-presence-test' , 'presence-test', true];
+        $tests[] = ['presence-private-test' , 'private-test', true];
+        $tests[] = ['presence-presence-test' , 'presence-test', true];
+        $tests[] = ['public-test' , 'public-test', false];
+
+        return $tests;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithUserForChannel($channel)
+    {
+        $request = m::mock(\Illuminate\Http\Request::class);
+        $request->channel_name = $channel;
+        $request->socket_id = 'abcd.1234';
+
+        $request->shouldReceive('input')
+                ->with('callback', false)
+                ->andReturn(false);
+
+        $user = m::mock('User');
+        $user->shouldReceive('getAuthIdentifier')
+             ->andReturn(42);
+
+        $request->shouldReceive('user')
+                ->andReturn($user);
+
+        return $request;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithoutUserForChannel($channel)
+    {
+        $request = m::mock(\Illuminate\Http\Request::class);
+        $request->channel_name = $channel;
+
+        $request->shouldReceive('user')
+                ->andReturn(null);
+
+        return $request;
+    }
+}

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -23,28 +23,6 @@ class PusherBroadcasterTest extends TestCase
         $this->broadcaster = m::mock(PusherBroadcaster::class, [$this->pusher])->makePartial();
     }
 
-    /**
-     * @dataProvider channelsProvider
-     */
-    public function testChannelNameNormalization($requestChannelName, $normalizedName)
-    {
-        $this->assertEquals(
-            $normalizedName,
-            $this->broadcaster->normalizeChannelName($requestChannelName)
-        );
-    }
-
-    /**
-     * @dataProvider channelsProvider
-     */
-    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
-    {
-        $this->assertEquals(
-            $guarded,
-            $this->broadcaster->isGuardedChannel($requestChannelName)
-        );
-    }
-
     public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
     {
         $this->broadcaster->channel('test', function() {
@@ -168,48 +146,6 @@ class PusherBroadcasterTest extends TestCase
             $data,
             $this->broadcaster->validAuthenticationResponse($request, true)
         );
-    }
-
-    public function channelsProvider()
-    {
-        $prefixesInfos = [
-            ['prefix' => 'private-', 'guarded' => true],
-            ['prefix' => 'presence-', 'guarded' => true],
-            ['prefix' => '', 'guarded' => false],
-        ];
-
-        $channels = [
-            'test',
-            'test-channel',
-            'test-private-channel',
-            'test-presence-channel',
-            'abcd.efgh',
-            'abcd.efgh.ijkl',
-            'test.{param}',
-            'test-{param}',
-            '{a}.{b}',
-            '{a}-{b}',
-            '{a}-{b}.{c}',
-        ];
-
-        $tests = [];
-        foreach ($prefixesInfos as $prefixInfos) {
-            foreach ($channels as $channel) {
-                $tests[] = [
-                    $prefixInfos['prefix'] . $channel,
-                    $channel,
-                    $prefixInfos['guarded'],
-                ];
-            }
-        }
-
-        $tests[] = ['private-private-test' , 'private-test', true];
-        $tests[] = ['private-presence-test' , 'presence-test', true];
-        $tests[] = ['presence-private-test' , 'private-test', true];
-        $tests[] = ['presence-presence-test' , 'presence-test', true];
-        $tests[] = ['public-test' , 'public-test', false];
-
-        return $tests;
     }
 
     /**

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting;
+
+use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RedisBroadcasterTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Broadcasting\Broadcasters\RedisBroadcaster
+     */
+    public $broadcaster;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testChannelNameNormalization($requestChannelName, $normalizedName)
+    {
+        $this->assertEquals(
+            $normalizedName,
+            $this->broadcaster->normalizeChannelName($requestChannelName)
+        );
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
+    {
+        $this->assertEquals(
+            $guarded,
+            $this->broadcaster->isGuardedChannel($requestChannelName)
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    {
+        $this->broadcaster->channel('test', function() {
+            return true;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    {
+        $this->broadcaster->channel('test', function() {
+            return false;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    {
+        $this->broadcaster->channel('test', function() {
+            return true;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('private-test')
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    {
+        $returnData = [1, 2, 3, 4];
+        $this->broadcaster->channel('test', function() use ($returnData) {
+            return $returnData;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    {
+        $this->broadcaster->channel('test', function() {
+            return;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    {
+        $this->broadcaster->channel('test', function() {
+            return [1, 2, 3, 4];
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('presence-test')
+        );
+    }
+
+    public function testValidAuthenticationResponseWithPrivateChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('private-test');
+
+        $this->assertEquals(
+            json_encode(true),
+            $this->broadcaster->validAuthenticationResponse($request, true)
+        );
+    }
+
+    public function testValidAuthenticationResponseWithPresenceChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('presence-test');
+
+        $this->assertEquals(
+            json_encode([
+                'channel_data' => [
+                    'user_id' => 42,
+                    'user_info' => [
+                        'a' => 'b',
+                        'c' => 'd',
+                    ],
+                ],
+            ]),
+            $this->broadcaster->validAuthenticationResponse($request, [
+                'a' => 'b',
+                'c' => 'd'
+            ])
+        );
+    }
+
+    public function channelsProvider()
+    {
+        $prefixesInfos = [
+            ['prefix' => 'private-', 'guarded' => true],
+            ['prefix' => 'presence-', 'guarded' => true],
+            ['prefix' => '', 'guarded' => false],
+        ];
+
+        $channels = [
+            'test',
+            'test-channel',
+            'test-private-channel',
+            'test-presence-channel',
+            'abcd.efgh',
+            'abcd.efgh.ijkl',
+            'test.{param}',
+            'test-{param}',
+            '{a}.{b}',
+            '{a}-{b}',
+            '{a}-{b}.{c}',
+        ];
+
+        $tests = [];
+        foreach ($prefixesInfos as $prefixInfos) {
+            foreach ($channels as $channel) {
+                $tests[] = [
+                    $prefixInfos['prefix'] . $channel,
+                    $channel,
+                    $prefixInfos['guarded'],
+                ];
+            }
+        }
+
+        $tests[] = ['private-private-test' , 'private-test', true];
+        $tests[] = ['private-presence-test' , 'presence-test', true];
+        $tests[] = ['presence-private-test' , 'private-test', true];
+        $tests[] = ['presence-presence-test' , 'presence-test', true];
+        $tests[] = ['public-test' , 'public-test', false];
+
+        return $tests;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithUserForChannel($channel)
+    {
+        $request = m::mock(\Illuminate\Http\Request::class);
+        $request->channel_name = $channel;
+
+        $user = m::mock('User');
+        $user->shouldReceive('getAuthIdentifier')
+             ->andReturn(42);
+
+        $request->shouldReceive('user')
+                ->andReturn($user);
+
+        return $request;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithoutUserForChannel($channel)
+    {
+        $request = m::mock(\Illuminate\Http\Request::class);
+        $request->channel_name = $channel;
+
+        $request->shouldReceive('user')
+                ->andReturn(null);
+
+        return $request;
+    }
+}

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -25,28 +25,6 @@ class RedisBroadcasterTest extends TestCase
         m::close();
     }
 
-    /**
-     * @dataProvider channelsProvider
-     */
-    public function testChannelNameNormalization($requestChannelName, $normalizedName)
-    {
-        $this->assertEquals(
-            $normalizedName,
-            $this->broadcaster->normalizeChannelName($requestChannelName)
-        );
-    }
-
-    /**
-     * @dataProvider channelsProvider
-     */
-    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
-    {
-        $this->assertEquals(
-            $guarded,
-            $this->broadcaster->isGuardedChannel($requestChannelName)
-        );
-    }
-
     public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
     {
         $this->broadcaster->channel('test', function() {
@@ -161,48 +139,6 @@ class RedisBroadcasterTest extends TestCase
                 'c' => 'd'
             ])
         );
-    }
-
-    public function channelsProvider()
-    {
-        $prefixesInfos = [
-            ['prefix' => 'private-', 'guarded' => true],
-            ['prefix' => 'presence-', 'guarded' => true],
-            ['prefix' => '', 'guarded' => false],
-        ];
-
-        $channels = [
-            'test',
-            'test-channel',
-            'test-private-channel',
-            'test-presence-channel',
-            'abcd.efgh',
-            'abcd.efgh.ijkl',
-            'test.{param}',
-            'test-{param}',
-            '{a}.{b}',
-            '{a}-{b}',
-            '{a}-{b}.{c}',
-        ];
-
-        $tests = [];
-        foreach ($prefixesInfos as $prefixInfos) {
-            foreach ($channels as $channel) {
-                $tests[] = [
-                    $prefixInfos['prefix'] . $channel,
-                    $channel,
-                    $prefixInfos['guarded'],
-                ];
-            }
-        }
-
-        $tests[] = ['private-private-test' , 'private-test', true];
-        $tests[] = ['private-presence-test' , 'presence-test', true];
-        $tests[] = ['presence-private-test' , 'private-test', true];
-        $tests[] = ['presence-presence-test' , 'presence-test', true];
-        $tests[] = ['public-test' , 'public-test', false];
-
-        return $tests;
     }
 
     /**

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting;
+
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Broadcasting\Broadcasters\UsePusherChannelsNames;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class UsePusherChannelsNamesTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Broadcasting\Broadcasters\RedisBroadcaster
+     */
+    public $broadcaster;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testChannelNameNormalization($requestChannelName, $normalizedName)
+    {
+        $this->assertEquals(
+            $normalizedName,
+            $this->broadcaster->normalizeChannelName($requestChannelName)
+        );
+    }
+
+    /**
+     * @dataProvider channelsProvider
+     */
+    public function testIsGuardedChannel($requestChannelName, $_, $guarded)
+    {
+        $this->assertEquals(
+            $guarded,
+            $this->broadcaster->isGuardedChannel($requestChannelName)
+        );
+    }
+
+    public function channelsProvider()
+    {
+        $prefixesInfos = [
+            ['prefix' => 'private-', 'guarded' => true],
+            ['prefix' => 'presence-', 'guarded' => true],
+            ['prefix' => '', 'guarded' => false],
+        ];
+
+        $channels = [
+            'test',
+            'test-channel',
+            'test-private-channel',
+            'test-presence-channel',
+            'abcd.efgh',
+            'abcd.efgh.ijkl',
+            'test.{param}',
+            'test-{param}',
+            '{a}.{b}',
+            '{a}-{b}',
+            '{a}-{b}.{c}',
+        ];
+
+        $tests = [];
+        foreach ($prefixesInfos as $prefixInfos) {
+            foreach ($channels as $channel) {
+                $tests[] = [
+                    $prefixInfos['prefix'] . $channel,
+                    $channel,
+                    $prefixInfos['guarded'],
+                ];
+            }
+        }
+
+        $tests[] = ['private-private-test' , 'private-test', true];
+        $tests[] = ['private-presence-test' , 'presence-test', true];
+        $tests[] = ['presence-private-test' , 'private-test', true];
+        $tests[] = ['presence-presence-test' , 'presence-test', true];
+        $tests[] = ['public-test' , 'public-test', false];
+
+        return $tests;
+    }
+}
+
+class FakeBroadcasterUsingPusherChannelsNames extends Broadcaster
+{
+    use UsePusherChannelsNames;
+
+    public function auth($request)
+    {
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+    }
+
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+    }
+}


### PR DESCRIPTION
I removed some code duplication and added tests for old and new features. `retrieveChannelOptions` is used only in `retrieveUser`now.

As `isGuardedChannel` and `normalizeChannelName`are the same for Redis and Pusher I made a trait. It could be used by a new broadcaster which would use the same prefix system... `auth` is the same method too but I prefer to keep it in each broadcaster.